### PR TITLE
Lock SUSHI to 1.3.2

### DIFF
--- a/fsh.ini
+++ b/fsh.ini
@@ -1,0 +1,2 @@
+[FSH]
+sushi-version=1.3.2


### PR DESCRIPTION
**Problem:** This project uses a project structure that will no longer be supported by SUSHI, as of SUSHI 2.0.0. If your project uses the HL7 IG Autobuild, auto builds will fail after SUSHI 2.0.0 comes out of beta.

**Temporary Solution (this PR):** You can "lock in" the version of SUSHI that the IG Publisher uses by creating or updating a `fsh.ini` file at the root of your project. For example, the following `fsh.ini` file tells the IG Publisher to always use SUSHI 1.3.2, even after SUSHI 2.0.0 is released:
```
[FSH]
sushi-version=1.3.2
```

**Preferred Solution:** The preferred way to fix this problem is to update your project to use the supported project structure and configuration (e.g., standard IG template project structure with an `input/fsh` folder). We suggest following the [Migrating from Older Versions](https://fshschool.org/docs/sushi/migration/) instructions on FSH School.

**Timeline:** In order to avoid being affected by the official SUSHI 2.0.0 release, we recommend you merge this PR or migrate the project by July 6, 2021.

**More Information / Questions**: For more information about SUSHI 2.0, you can read the
[SUSHI 2.0.0 Beta 1 Release Notes](https://github.com/FHIR/sushi/releases/tag/v2.0.0-beta.1). For more information about updating your project to the supported project structure, see [Migrating from Older Versions](https://fshschool.org/docs/sushi/migration/) on FSH School. If you have questions, you can reach out to the SUSHI team via the [#shorthand](https://chat.fhir.org/#narrow/stream/215610-shorthand) stream on Zulip or by [logging an issue on SUSHI](https://github.com/FHIR/sushi/issues).